### PR TITLE
Update Default NDA Terms Id from 21153 to 21343

### DIFF
--- a/components/project_management/src/java/main/com/topcoder/management/project/persistence/AbstractInformixProjectPersistence.java
+++ b/components/project_management/src/java/main/com/topcoder/management/project/persistence/AbstractInformixProjectPersistence.java
@@ -532,7 +532,7 @@ public abstract class AbstractInformixProjectPersistence implements ProjectPersi
      * 
      * @since 1.1.2
      */
-    public static final long STANDARD_CCA_TERMS_ID = 21153; //21113;   //20713;
+    public static final long STANDARD_CCA_TERMS_ID = 21343; //21153; //21113;   //20713;
 
     
 


### PR DESCRIPTION
Change the default terms Id to 21343. The terms will be applicable when the user selects "NDA" on a direct challenge.