### PR TITLE
redirect project creation to connect

### DIFF
--- a/conf/ApplicationServer.properties
+++ b/conf/ApplicationServer.properties
@@ -46,3 +46,5 @@ SSO_DOMAIN = @ApplicationServer.SSO_DOMAIN@
 
 JWT_V3_COOKIE_KEY = @ApplicationServer.JWT_V3_COOKIE_KEY@
 JWT_COOKIE_KEY = @ApplicationServer.JWT_COOKIE_KEY@
+
+TOPCODER_CONNECT_URL=@TopcoderConnectUrl@

--- a/src/java/main/com/topcoder/direct/services/configs/ServerConfiguration.java
+++ b/src/java/main/com/topcoder/direct/services/configs/ServerConfiguration.java
@@ -58,4 +58,9 @@ public class ServerConfiguration extends ApplicationServer {
     public static String JWT_V3_COOKIE_KEY = bundle.getProperty("JWT_V3_COOKIE_KEY", "v3jwt");
 
     public static String JWT_COOKIE_KEY = bundle.getProperty("JWT_COOKIE_KEY", "tcjwt");
+
+    /**
+     * The Topcoder Connect URL
+     */
+    public static String TOPCODER_CONNECT_URL = bundle.getProperty("TOPCODER_CONNECT_URL", "https://connect.topcoder.com");
 }

--- a/src/web/WEB-INF/includes/newHeader.jsp
+++ b/src/web/WEB-INF/includes/newHeader.jsp
@@ -34,6 +34,8 @@
 <%@ page import="com.topcoder.direct.services.configs.ServerConfiguration" %>
 <%@ include file="/WEB-INF/includes/taglibs.jsp" %>
 
+<c:set var="TCConnectURL" value="<%=ServerConfiguration.TOPCODER_CONNECT_URL%>"/>
+
 <!-- topcoder maintenance module -->
 <div id="topcoder-maintenance-notification">
     <div class="content">
@@ -132,7 +134,7 @@
 
         <ul>
             <li>
-                <a class="first" href="<s:url action="createNewProject" namespace="/"/>">Start New</a>
+                <a class="first" href="${TCConnectURL}" target="_blank">Start New</a>
             </li>
             <s:if test="%{#session.currentSelectDirectProjectID > 0 && sessionData.currentProjectContext.name != null}">
                 <input type="hidden" name="topNavCurrentProjectId" value="<s:property value='%{#session.currentSelectDirectProjectID}'/>"/>
@@ -422,7 +424,7 @@
         <c:if test="${requestScope.CURRENT_TAB eq 'enterprise' and !requestScope.NO_ENTERPRISE_DASHBOARD_TOP}">
             <div class="topBtns" id="enterpriseDashboardTop">
                 <a href="${ctx}/copilot/launchCopilotContest" class="copilot" title="Finds a TopCoder Copilot for your project">Get a Copilot</a>
-                <a href="<s:url action="createNewProject" namespace="/"/>" class="start" title="Starts a new project">Start a Project</a>
+                <a href="${TCConnectURL}" target="_blank" class="start" title="Starts a new project">Start a Project</a>
                 <a href="${ctx}/launch/home" class="launch" title="Launch a new challenge for your project">Launch Challenge</a>
             </div>
         </c:if>

--- a/src/web/WEB-INF/includes/right.jsp
+++ b/src/web/WEB-INF/includes/right.jsp
@@ -32,7 +32,10 @@
   - the data via ajax.
   -
 --%>
+<%@ page import="com.topcoder.direct.services.configs.ServerConfiguration" %>
 <%@ include file="/WEB-INF/includes/taglibs.jsp" %>
+
+<c:set var="TCConnectURL" value="<%=ServerConfiguration.TOPCODER_CONNECT_URL%>"/>
 
 <div id="area2" class="dashboardPage"><!-- the right column -->
 
@@ -40,8 +43,7 @@
         <div class="topBtns">
             <a href="${ctx}/copilot/launchCopilotContest" class="copilot"
                title="Finds a TopCoder Copilot for your project">Get a Copilot</a>
-            <a href="<s:url action="createNewProject" namespace="/"/>" class="start" title="Starts a new project">Start
-            a Project</a>
+               <a href="${TCConnectURL}" target="_blank" class="start" title="Starts a new project">Start a Project</a>
             <a href="${ctx}/launch/home" class="launch" title="Launch a new challenge for your project">Launch
                 Challenge</a>
         </div>

--- a/token.properties.docker
+++ b/token.properties.docker
@@ -350,3 +350,6 @@
 
 @trialBillingId@ =
 @defaultGroupIdForTrial@ =
+
+# The Topcoder Connect Url to which the projects creation will redirect
+@TopcoderConnectUrl@=https://connect.topcoder-dev.com

--- a/token.properties.example
+++ b/token.properties.example
@@ -398,3 +398,6 @@
 @userGroupsApiEndpoint@=http://172.18.0.1:8080/v3/groups
 @trialBillingId@ = 3
 @defaultGroupIdForTrial@ = 12347
+
+# The Topcoder Connect Url to which the projects creation will redirect
+@TopcoderConnectUrl@=https://connect.topcoder.com 


### PR DESCRIPTION
The "Create project" links in direct should redirect to connect app.
Connect app url should be configured in token.properties using the parameter '@TopcoderConnectUrl@'
For example for the dev environment: @TopcoderConnectUrl@=https://connect.topcoder-dev.com

Demo on local setup: https://monosnap.com/direct/9W6yo4Ies8Mf5LFD9QqbXQjLfOtPE7