### PR TITLE
Fixing bad request with groups api call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
           context : org-global      
           filters:
             branches:
-              only: [dev, dev-sts, 'feature/bad_request_group_api_issue%23539']
+              only: [dev, dev-sts, 'feature/bad_request_group_api_issue#539']
       - build-qa:
           context : org-global      
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
           context : org-global      
           filters:
             branches:
-              only: [dev, dev-sts]
+              only: [dev, dev-sts, 'feature/bad_request_group_api_issue%23539']
       - build-qa:
           context : org-global      
           filters:

--- a/src/java/main/com/topcoder/direct/services/view/util/DirectUtils.java
+++ b/src/java/main/com/topcoder/direct/services/view/util/DirectUtils.java
@@ -3876,6 +3876,7 @@ public final class DirectUtils {
 
         if (!DirectUtils.isCockpitAdmin(tcSubject) && !DirectUtils.isTcStaff(tcSubject)) {
             uri.setParameter("memberId", String.valueOf(tcSubject.getUserId()));
+            uri.setParameter("membershipType", "user");
         }
 
         uri.setParameter(PER_PAGE, PER_PAGE_VALUE);


### PR DESCRIPTION
V5 groups api expects `membershipType=user` along with `memberId` param.